### PR TITLE
use main-XXX in staging environment

### DIFF
--- a/.github/workflows/wc-update-ecs-manifest.yml
+++ b/.github/workflows/wc-update-ecs-manifest.yml
@@ -76,7 +76,7 @@ jobs:
             IMAGE_TAG=release-${GITHUB_REF#refs/*/}
           elif [ "${{ inputs.environment }}" == "stg" ]; then
             # For staging, use the commit hash as the docker image's tag
-            IMAGE_TAG=commit-${{ github.sha }}
+            IMAGE_TAG=main-${{ github.sha }}
           else
             echo "unknown environments: ${{ inputs.environment }}"
             exit 1


### PR DESCRIPTION
### confirm that `main-XXX` tag is only pushed when main branch

* [action for `main` branch](https://github.com/cloudnativedaysjp/dreamkast/actions/runs/15164943771)
* [action for `fix-sponsor-logo-url` branch](https://github.com/cloudnativedaysjp/dreamkast/actions/runs/15164781550/job/43684705224)

### related PRs

* #34 
* #35