### PR TITLE
fix: preserve newlines in metadata tags when creating multi-arch manifest

### DIFF
--- a/.github/workflows/wc-build-image.yml
+++ b/.github/workflows/wc-build-image.yml
@@ -131,13 +131,16 @@ jobs:
         uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
 
       - name: Create multi-arch manifest
+        env:
+          TAGS: ${{ steps.meta.outputs.tags }}
+          IMAGE_BASE: ${{ steps.login-ecr.outputs.registry }}/${{ inputs.image_name }}
+          SHA: ${{ github.sha }}
         run: |
-          image_base="${{ steps.login-ecr.outputs.registry }}/${{ inputs.image_name }}"
-          for tag in ${{ steps.meta.outputs.tags }}; do
+          for tag in $TAGS; do
             docker buildx imagetools create \
               --tag "${tag}" \
-              "${image_base}:${{ github.sha }}-amd64" \
-              "${image_base}:${{ github.sha }}-arm64"
+              "${IMAGE_BASE}:${SHA}-amd64" \
+              "${IMAGE_BASE}:${SHA}-arm64"
           done
       # trivyのスキャンが転けるのでコメントアウト
       # - name: Run Trivy vulnerability scanner


### PR DESCRIPTION
## Summary
- `wc-build-image.yml` の `Create multi-arch manifest` ステップで、`docker/metadata-action` の `tags` 出力を直接シェルスクリプトに展開していたため、タグが複数生成される（例: `main` ブランチで `branch-main` と `main-<sha>` の2つが出る）ケースで以下のようなシンタックスエラーになっていた:
  ```
  for tag in .../dreamkast-ui:branch-main
  .../dreamkast-ui:main-<sha>; do
  ...: line 3: syntax error near unexpected token `.../dreamkast-ui:main-<sha>'
  ```
- `tags` は改行区切りで出力されるため、GitHub Actions の式展開が改行をそのままスクリプトに挿入してしまうのが原因。
- 修正: タグや image base などを `env` 経由で渡し、bash の単語分割に任せるようにした。これで改行・空白の両方を正しく扱える。

## 背景
cloudnativedaysjp/dreamkast-ui の main ブランチビルドで顕在化: https://github.com/cloudnativedaysjp/dreamkast-ui/actions/runs/24279097923

ブランチビルドではタグが1つしか生成されないため、このバグはこれまで潜在化していた。

## Test plan
- [ ] cloudnativedaysjp/dreamkast-ui の main ブランチへ push 後、`build container image when branches are pushed` workflow の `merge` ジョブが成功することを確認
- [ ] 非 main ブランチへの push でも引き続き merge ジョブが通ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)